### PR TITLE
Updates to support Oracle Linux 8

### DIFF
--- a/cloudformation/15-patch-baselines.yaml
+++ b/cloudformation/15-patch-baselines.yaml
@@ -113,6 +113,38 @@ Resources:
       #   PatchFilterGroup
       # Sources : PatchSource
 
+  OraclePatchBaseline:
+    Type: "AWS::SSM::PatchBaseline"
+    Properties:
+      Name: cu-cit-cloud-team-patching-Oracle
+      # Options: WINDOWS | AMAZON_LINUX | AMAZON_LINUX_2 | AMAZON_LINUX_2022 | UBUNTU | REDHAT_ENTERPRISE_LINUX | SUSE | CENTOS | ORACLE_LINUX | DEBIAN | MACOS | RASPBIAN | ROCKY_LINUX | ALMA_LINUX | AMAZON_LINUX_2023
+      OperatingSystem: ORACLE_LINUX
+      Description: "Patch baseline for use with https://github.com/CU-CommunityApps/ct-patching-scanning"
+      PatchGroups:
+        - cu-cit-cloud-team-patching
+      ApprovalRules:
+        PatchRules:
+          - PatchFilterGroup:
+              # See https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_PatchFilter.html
+              # PRODUCT | CLASSIFICATION | MSRC_SEVERITY | PATCH_ID | SECTION | PRIORITY | SEVERITY
+              PatchFilters:
+                - Key: PRODUCT
+                  Values:
+                    - "*"
+            ApproveAfterDays: !Ref PatchApprovalDelayParam
+            ComplianceLevel: UNSPECIFIED
+            EnableNonSecurity: true
+      # ApprovedPatches:
+      #   - String
+      ApprovedPatchesComplianceLevel: UNSPECIFIED
+      ApprovedPatchesEnableNonSecurity: false
+      # RejectedPatches:
+      #   - String
+      RejectedPatchesAction: ALLOW_AS_DEPENDENCY
+      # GlobalFilters:
+      #   PatchFilterGroup
+      # Sources : PatchSource
+
   RHELPatchBaseline:
     Type: "AWS::SSM::PatchBaseline"
     Properties:

--- a/cloudformation/20-patching.yaml
+++ b/cloudformation/20-patching.yaml
@@ -635,7 +635,15 @@ Resources:
             timeoutSeconds: 300
             runCommand:
               - "#!/bin/bash"
-              - if [ -n "$(command -v yum)" ] ; then
+              - if [ -n "$(command -v dnf)" ] ; then
+              -   echo Using dnf
+              -   uname -r
+              -   echo Kernels before cleanup
+              -   rpm -qa kernel
+              -   dnf remove --oldinstallonly --setopt installonly_limit=2
+              -   echo Kernels after cleanup
+              -   rpm -qa kernel    
+              - elif [ -n "$(command -v yum)" ] ; then
               -   echo Using yum
               -   uname -r
               -   echo Kernels before cleanup


### PR DESCRIPTION
Updates to support Oracle Linux 8 from @gdelisle. From @gdelisle in #4: 

> I have written support for Oracle Linux 8 into our fork of this project: https://github.com/cul-it/ct-patching-scanning
> Salient differences are in the last commit: https://github.com/cul-it/ct-patching-scanning/commit/d5beeef3622751bfe5ddc4dc4b96cd0308cbf851
> 
> The changes involve 1) adding a PatchBaseLine for Oracle Linux, which is now an option within SSM Inspector. This should be forward-compatible with future OL versions. 2) adjusting the PatchAndRemoveKernelsSSMDoc script, which breaks with OS versions > 7 because of breaking changes with the package-cleanup tool. To get around this, I added a conditional to detect the presence of dnf and remove old kernels with that tool instead. The command to remove old kernels with dnf is dnf remove --oldinstallonly --setopt installonly_limit=2. If dnf is not detected, it's assumed that the OS is RHEL-based >= 7 and the package-cleanup command is used as before.
> 
> This patch is not tested with OL > 8 but it is installed in our environment, it is working on our OL 8 machines and it is not disrupting our CentOS 7 or Amazon Linux 2 patching.